### PR TITLE
Relevantobject changed back to class

### DIFF
--- a/src/AutomatedCar/Models/RelevantObject.cs
+++ b/src/AutomatedCar/Models/RelevantObject.cs
@@ -6,7 +6,7 @@
     using System.Text;
     using System.Threading.Tasks;
 
-    public struct RelevantObject
+    public class RelevantObject
     {
         public RelevantObject(WorldObject relevantobject, double currentdistance, double previousdistance)
         {


### PR DESCRIPTION
Now the Current- and PrevousDistances are correctly calculated and sent in the RelevantObjectPacket

(Köszi Krisztián <3)